### PR TITLE
Disable default PMD rules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ allprojects {
         consoleOutput = true
         ignoreFailures = false
         toolVersion = "6.22.0"
+        ruleSets = []
         ruleSetFiles = rootProject.files("config/pmd/ruleset.xml")
     }
 }


### PR DESCRIPTION
Some PMD rules seem to be active by default.

The following PMD warning should normally be excluded in our config file but still appears:
Found non-transient, non-static member. Please mark as transient or provide accessors.

This leads to excessive use of transient fields and useless getters as reported by Lander earlier.
This PR tries to solve that issue by disabling the PMD rules active by default and only rely on the list of PMD checks that we want.