### PR TITLE
added Test for plugin with default groupid

### DIFF
--- a/autobump-maven/src/test/java/com/github/autobump/maven/model/MavenDependencyResolverTest.java
+++ b/autobump-maven/src/test/java/com/github/autobump/maven/model/MavenDependencyResolverTest.java
@@ -25,6 +25,7 @@ public class MavenDependencyResolverTest {
     private static final  String TEST_DEPENDENCY_VERSION = "10.15.2.0";
     private Workspace workspace;
     private Workspace pluginWorkspace;
+    private Workspace pluginDefaultGroupIdWorkspace;
     private Workspace multiModuleWorkspace;
     private Workspace parentDependencyWorkspace;
     private DependencyResolver resolver;
@@ -33,6 +34,7 @@ public class MavenDependencyResolverTest {
     public void setUp() {
         workspace = new Workspace("src/test/resources/project_root");
         pluginWorkspace = new Workspace("src/test/resources/project_root_plugins");
+        pluginDefaultGroupIdWorkspace = new Workspace("src/test/resources/project_root_plugins/pluginsDefaultGroupId");
         multiModuleWorkspace = new Workspace("src/test/resources/multi_module_root");
         parentDependencyWorkspace = new Workspace("src/test/resources/parent_dependency_root");
         resolver = new MavenDependencyResolver();
@@ -155,6 +157,18 @@ public class MavenDependencyResolverTest {
     }
 
     @Test
+    void getPluginsWithDefaultGroupId(){
+        Set<Dependency> plugins = resolver.resolve(pluginDefaultGroupIdWorkspace);
+
+        assertTrue(plugins.contains(MavenDependency.builder()
+                .group("org.apache.maven.plugins")
+                .name("maven-compiler-plugin")
+                .version("3.8.1")
+                .type(DependencyType.PLUGIN)
+                .build()));
+    }
+
+    @Test
     void testEmptyBuild() {
         pluginWorkspace = new Workspace(pluginWorkspace.getProjectRoot() + "/emptyBuild");
         Set<Dependency> plugins = resolver.resolve(pluginWorkspace);
@@ -225,7 +239,7 @@ public class MavenDependencyResolverTest {
     }
 
     @Test
-    void testGetParedntDependency(){
+    void testGetParentDependency(){
         assertTrue(resolver.resolve(parentDependencyWorkspace)
                 .contains(
                         MavenDependency

--- a/autobump-maven/src/test/resources/project_root_plugins/pluginsDefaultGroupId/pom.xml
+++ b/autobump-maven/src/test/resources/project_root_plugins/pluginsDefaultGroupId/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>be.gschrooyen</groupId>
+    <artifactId>restaurantdag</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>restaurantdag_organizer</name>
+    <description>Demo project for Spring Boot</description>
+
+    <properties>
+        <testVersion>10.15.2.0</testVersion>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Only a test was added. The existing MavenDependencyResolver already appeared to detect Maven plugin dependencies without groupId and fallback to the default groupId for these plugin dependencies.